### PR TITLE
Lock down Python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine3.6
+FROM python:3.6.3-alpine3.6
 
 LABEL maintainer "Hamza Sheikh <code@codeghar.com>"
 


### PR DESCRIPTION
I think it's best to keep tabs on your dependencies.
Or we can get a surprise update of the dependent layer ;)
For reference this is the dockerfile of that image: https://github.com/docker-library/python/blob/master/3.6/alpine3.6/Dockerfile