### PR TITLE
Use venv stdlib instead of 3rd party virtualenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,21 +3,22 @@ FROM python:alpine3.6
 LABEL maintainer "Hamza Sheikh <code@codeghar.com>"
 
 RUN apk update && \
-    apk add gcc && \
-    apk add python3-dev && \
-    apk add musl-dev && \
-    apk add libffi-dev && \
-    apk add openssl-dev && \
-    apk add make && \
-    apk add openssh-client && \
-    python3 -m pip install virtualenv && \
-    python3 -m virtualenv /usr/local/share/ansible-virtualenv && \
+    apk add \
+            gcc \
+            libffi-dev \
+            make \
+            musl-dev \
+            openssh-client \
+            openssl-dev \
+            python3-dev && \
+    python3 -m venv /usr/local/share/ansible-virtualenv && \
     /usr/local/share/ansible-virtualenv/bin/pip install ansible && \
-    apk del gcc && \
-    apk del python3-dev && \
-    apk del musl-dev && \
-    apk del libffi-dev && \
-    apk del openssl-dev && \
+    apk del \
+            gcc \
+            libffi-dev \
+            musl-dev \
+            openssl-dev \
+            python3-dev && \
     mkdir -p /srv/ansible && \
     mkdir -p /root/.ssh
 


### PR DESCRIPTION
Combined apk commands and sorted apk packages.
Formatted for readability & maintainability