### PR TITLE
Use alpine official image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,34 +2,12 @@ FROM alpine:3.6
 
 LABEL maintainer "https://github.com/aikchar/ansible-in-docker-container"
 
-# pip installation inspired by https://github.com/docker-library/python/blob/master/3.6/alpine3.6/Dockerfile
 RUN apk update && \
     apk add \
             ca-certificates \
             python3=3.6.1-r3 &&\
     ln -s /usr/bin/python3 /usr/bin/python &&\
-    set -ex; \
-	apk add --no-cache --virtual .fetch-deps libressl; \
-	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	apk del .fetch-deps; \
-	\
-	python3 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip==9.0.1" \
-	; \
     ln -s /usr/bin/pip3 /usr/bin/pip &&\
-	pip --version; \
-	\
-	find /usr/local -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py &&\
 	apk add --virtual=build \
             gcc \
             libffi-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk update && \
             python3=3.6.1-r3 &&\
     ln -s /usr/bin/python3 /usr/bin/python &&\
     ln -s /usr/bin/pip3 /usr/bin/pip &&\
-	apk add --virtual=build \
+    apk add --virtual=build \
             gcc \
             libffi-dev \
             make \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM alpine:3.6
 
 LABEL maintainer "https://github.com/aikchar/ansible-in-docker-container"
 
+# TODO: add comments within RUN step with echo command
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories &&\
-    apk update && \
+    apk update &&\
     apk add --no-cache \
             ca-certificates \
             python3=3.6.3-r9 &&\
@@ -17,10 +18,12 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositorie
             openssh-client \
             openssl-dev \
             python3-dev=3.6.3-r9 &&\
-    pip install --no-cache-dir --disable-pip-version-check ansible==2.4.1.0 && \
+    pip install --no-cache-dir --disable-pip-version-check ansible==2.4.1.0 &&\
     apk del --purge build &&\
-    mkdir -p /srv/ansible && \
+    mkdir -p /srv/ansible &&\
     mkdir -p /root/.ssh
+    # The following command cuts image size by 40 MB
+    # find . -type f -name "*.py[co]" -delete -or -type d -name "__pycache__" -delete
 
 WORKDIR /srv/ansible
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM alpine:3.6
 LABEL maintainer "https://github.com/aikchar/ansible-in-docker-container"
 
 # TODO: add comments within RUN step with echo command
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories &&\
+RUN set -x &&\
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories &&\
     apk update &&\
     apk add --no-cache \
             ca-certificates \
@@ -20,10 +21,9 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositorie
             python3-dev=3.6.3-r9 &&\
     pip install --no-cache-dir --disable-pip-version-check ansible==2.4.1.0 &&\
     apk del --purge build &&\
+    find / -type f -name "*.py[co]" -delete -or -type d -name "__pycache__" -delete &&\
     mkdir -p /srv/ansible &&\
     mkdir -p /root/.ssh
-    # The following command cuts image size by 40 MB
-    # find . -type f -name "*.py[co]" -delete -or -type d -name "__pycache__" -delete
 
 WORKDIR /srv/ansible
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,22 @@
-FROM python:3.6.3-alpine3.6
+FROM alpine:3.6
 
 LABEL maintainer "https://github.com/aikchar/ansible-in-docker-container"
 
 RUN apk update && \
     apk add \
+            python3=3.6.1-r3 \
+            ca-certificates &&\
+    apk add --virtual=build \
             gcc \
             libffi-dev \
             make \
             musl-dev \
             openssh-client \
             openssl-dev \
-            python3-dev && \
+            python3-dev=3.6.1-r3 &&\
     python3 -m venv /usr/local/share/ansible-virtualenv && \
     /usr/local/share/ansible-virtualenv/bin/pip install ansible==2.4.1.0 && \
-    apk del \
-            gcc \
-            libffi-dev \
-            musl-dev \
-            openssl-dev \
-            python3-dev && \
+    apk del --purge build &&\
     mkdir -p /srv/ansible && \
     mkdir -p /root/.ssh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,22 @@ FROM alpine:3.6
 
 LABEL maintainer "https://github.com/aikchar/ansible-in-docker-container"
 
-RUN apk update && \
-    apk add \
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories &&\
+    apk update && \
+    apk add --no-cache \
             ca-certificates \
-            python3=3.6.1-r3 &&\
+            python3=3.6.3-r9 &&\
     ln -s /usr/bin/python3 /usr/bin/python &&\
     ln -s /usr/bin/pip3 /usr/bin/pip &&\
-    apk add --virtual=build \
+    apk add --no-cache --virtual=build \
             gcc \
             libffi-dev \
             make \
             musl-dev \
             openssh-client \
             openssl-dev \
-            python3-dev=3.6.1-r3 &&\
-    pip install ansible==2.4.1.0 && \
+            python3-dev=3.6.3-r9 &&\
+    pip install --no-cache-dir --disable-pip-version-check ansible==2.4.1.0 && \
     apk del --purge build &&\
     mkdir -p /srv/ansible && \
     mkdir -p /root/.ssh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,35 @@ FROM alpine:3.6
 
 LABEL maintainer "https://github.com/aikchar/ansible-in-docker-container"
 
+# pip installation inspired by https://github.com/docker-library/python/blob/master/3.6/alpine3.6/Dockerfile
 RUN apk update && \
     apk add \
-            python3=3.6.1-r3 \
-            ca-certificates &&\
-    apk add --virtual=build \
+            ca-certificates \
+            python3=3.6.1-r3 &&\
+    ln -s /usr/bin/python3 /usr/bin/python &&\
+    set -ex; \
+	apk add --no-cache --virtual .fetch-deps libressl; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	apk del .fetch-deps; \
+	\
+	python3 get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==9.0.1" \
+	; \
+    ln -s /usr/bin/pip3 /usr/bin/pip &&\
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py &&\
+	apk add --virtual=build \
             gcc \
             libffi-dev \
             make \
@@ -14,14 +38,11 @@ RUN apk update && \
             openssh-client \
             openssl-dev \
             python3-dev=3.6.1-r3 &&\
-    python3 -m venv /usr/local/share/ansible-virtualenv && \
-    /usr/local/share/ansible-virtualenv/bin/pip install ansible==2.4.1.0 && \
+    pip install ansible==2.4.1.0 && \
     apk del --purge build &&\
     mkdir -p /srv/ansible && \
     mkdir -p /root/.ssh
 
 WORKDIR /srv/ansible
-
-ENV PATH=/usr/local/share/ansible-virtualenv/bin:$PATH
 
 VOLUME [ "/srv/ansible" ]


### PR DESCRIPTION
** updated **
- install alpine official python pkg
- install ansible on system level
- use --no-cache to reduce image size

```
REPOSITORY                  TAG                     IMAGE ID            CREATED             SIZE
dmitrytokarev/ansible       py3.6.3-no-cache        95750785f7fe        16 minutes ago      107MB
```

the problem this solves:
- we build/install ansible + deps on python 3.6.1 but run on python 3.6.3
- ansible is installed in virt env which doesn't give us any benefits - system level is fine, since it's a single purpose container
- simplified Dockerfile
- reduced image size to 107MB
- Should improve image build time