### PR TITLE
Upgraded alpine to 3.7 and ansible to 2.4.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 LABEL maintainer "https://github.com/aikchar/ansible-in-docker-container"
 
 # TODO: add comments within RUN step with echo command
 RUN set -x &&\
-    echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories &&\
     apk update &&\
     apk add --no-cache \
             ca-certificates \
             python3=3.6.3-r9 &&\
-    ln -s /usr/bin/python3 /usr/bin/python &&\
-    ln -s /usr/bin/pip3 /usr/bin/pip &&\
+    cd /usr/bin &&\
+    ln -s python3 python &&\
+    ln -s pip3 pip &&\
+    pip install --no-cache-dir -U setuptools &&\
     apk add --no-cache --virtual=build \
             gcc \
             libffi-dev \
@@ -19,7 +20,7 @@ RUN set -x &&\
             openssh-client \
             openssl-dev \
             python3-dev=3.6.3-r9 &&\
-    pip install --no-cache-dir --disable-pip-version-check ansible==2.4.1.0 &&\
+    pip install --no-cache-dir --disable-pip-version-check ansible==2.4.2.0 &&\
     apk del --purge build &&\
     find / -type f -name "*.py[co]" -delete -or -type d -name "__pycache__" -delete &&\
     mkdir -p /srv/ansible &&\


### PR DESCRIPTION
- alpine 3.7 released no need to use edge repo any longer!
- bugfix upgrade of ansible. See deets here: https://github.com/ansible/ansible/blob/v2.4.2.0-1/CHANGELOG.md
- upgrade setuptools before installing anything